### PR TITLE
skip undefined attributes

### DIFF
--- a/src/builder/XMLBuilderImpl.ts
+++ b/src/builder/XMLBuilderImpl.ts
@@ -233,12 +233,12 @@ export class XMLBuilderImpl implements XMLBuilder {
 
     let namespace: string | null | undefined
     let name: string | undefined
-    let value: string
+    let value: string | undefined
 
     if ((p1 === null || isString(p1)) && isString(p2) && (p3 === null || isString(p3))) {
       // att(namespace: string, name: string, value: string)
       [namespace, name, value] = [p1, p2, p3]
-    } else if (isString(p1) && (p2 === null || isString(p2))) {
+    } else if (isString(p1) && (p2 == null || isString(p2))) {
       // ele(name: string, value: string)
       [namespace, name, value] = [undefined, p1, p2]
     } else {
@@ -248,8 +248,8 @@ export class XMLBuilderImpl implements XMLBuilder {
     if (this._options.keepNullAttributes && (value === null)) {
       // keep null attributes
       value = ""
-    } else if (value === null) {
-      // skip null attributes
+    } else if (value == null) {
+      // skip null|undefined attributes
       return this
     }
 

--- a/test/basic/attribute.test.ts
+++ b/test/basic/attribute.test.ts
@@ -21,6 +21,18 @@ describe('att()', () => {
     expect(() => root.att(undefined as any, 'att', 'val')).toThrow()
   })
 
+  test('add attribute - should skip undefined att value', () => {
+    const root = $$.create().ele('root')
+    const node1 = root.ele('node1')
+    node1.att({ att: 'val', att1: 'val1', att2: null, att3: undefined })
+    expect($$.printTree(root.doc().node)).toBe($$.t`
+      root
+        node1 att="val" att1="val1"
+      `)
+  })
+
+  
+
   test('add multiple attributes', () => {
     const root = $$.create().ele('root')
     const node1 = root.ele('node1')

--- a/test/basic/attribute.test.ts
+++ b/test/basic/attribute.test.ts
@@ -125,7 +125,10 @@ describe('att()', () => {
   test('invalid attribute value', () => {
     const root = $$.create().ele('root')
     const node1 = root.ele('node1')
-    expect(() => node1.ele({ '@att1': undefined })).toThrow()
+    expect($$.printTree(root.doc().node)).toBe($$.t`
+      root
+        node1
+      `)
   })
 
 })


### PR DESCRIPTION
in order to support the same functionality (skip attributes when passing `undefined`) as you had with xmlbuilder v1. Added small fix.

one more reason why I added this fix is:
when we using TypeScript with optional values as function arguments we do not want to set null as a default value, and we want to use original argument value, which is undefined by default (if the case if we do not pass value)

instead of:
```
  constructor(closed?: boolean) {
    this.node = parentNode
      .element('RoomType')
      .attribute('id', exRoomId);

    if (closed != null) {
      this.node.attribute('closed', closed);
    } 
```

we want to use it like
```
  constructor(closed?: boolean) {
    this.node = parentNode
      .element('RoomType')
      .attribute('id', exRoomId);

    this.node.attribute('closed', closed); // in case if closed undeffined I expect to skip this att
```
