### PR TITLE
Fix noDoubleEncoding with undefined XML entities

### DIFF
--- a/src/builder/XMLBuilderCBImpl.ts
+++ b/src/builder/XMLBuilderCBImpl.ts
@@ -205,7 +205,7 @@ export class XMLBuilderCBImpl extends EventEmitter implements XMLBuilderCB {
 
     let markup = ""
     if (this._options.noDoubleEncoding) {
-      markup = node.data.replace(/(?!&\S+;)&/g, '&amp;')
+      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/\r/g, '&#xD;')
@@ -673,7 +673,7 @@ export class XMLBuilderCBImpl extends EventEmitter implements XMLBuilderCB {
     if (value === null) return ""
 
     if (this._options.noDoubleEncoding) {
-      return value.replace(/(?!&\S+;)&/g, '&amp;')
+      return value.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/"/g, '&quot;')
         .replace(/\t/g, '&#x9;')

--- a/src/writers/BaseWriter.ts
+++ b/src/writers/BaseWriter.ts
@@ -931,7 +931,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
     let markup = ""
 
     if (noDoubleEncoding) {
-      markup = node.data.replace(/(?!&\S+;)&/g, '&amp;')
+      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/\r/g, '&#xD;')
@@ -1615,7 +1615,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * also replacing ">" characters.
      */
     if (noDoubleEncoding) {
-      return value.replace(/(?!&\S+;)&/g, '&amp;')
+      return value.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/"/g, '&quot;')
         .replace(/\t/g, '&#x9;')

--- a/test/callback/basic.test.ts
+++ b/test/callback/basic.test.ts
@@ -149,8 +149,8 @@ describe('basic callback API tests', () => {
   test('No double encoding', (done) => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
@@ -159,16 +159,16 @@ describe('basic callback API tests', () => {
     xmlStream.ele(obj).end()
 
     $$.expectCBResult(xmlStream,
-      '<root att="attribute value with &num; and &#35;">' +
-      'HTML entities for umlaut are &uuml; and &#252;.' +
+      '<root att="attribute value with &amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp; and &amp;#38;.' +
       '</root>', done)
   })
 
   test('Double encoding', (done) => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
@@ -177,16 +177,16 @@ describe('basic callback API tests', () => {
     xmlStream.ele(obj).end()
 
     $$.expectCBResult(xmlStream,
-      '<root att="attribute value with &amp;num; and &amp;#35;">' +
-      'HTML entities for umlaut are &amp;uuml; and &amp;#252;.' +
+      '<root att="attribute value with &amp;amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp;amp; and &amp;#38;.' +
       '</root>', done)
   })
 
   test('Double encoding - default behavior', (done) => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
@@ -195,8 +195,8 @@ describe('basic callback API tests', () => {
     xmlStream.ele(obj).end()
 
     $$.expectCBResult(xmlStream,
-      '<root att="attribute value with &amp;num; and &amp;#35;">' +
-      'HTML entities for umlaut are &amp;uuml; and &amp;#252;.' +
+      '<root att="attribute value with &amp;amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp;amp; and &amp;#38;.' +
       '</root>', done)
   })
 

--- a/test/issues/issue-016.test.ts
+++ b/test/issues/issue-016.test.ts
@@ -1,0 +1,21 @@
+import $$ from "../TestHelpers";
+
+describe("Replicate issue", () => {
+  // https://github.com/oozcitak/xmlbuilder2/issues/16
+  test("#16 - Named entities produce invalid XML", () => {
+    expect(
+      $$.convert(
+        { example: "&lt;p&gt;Hello&nbsp;World&lt;/p&gt;" },
+        { format: "xml", noDoubleEncoding: true }
+      )
+    ).toBe(
+      '<?xml version="1.0"?><example>&lt;p&gt;Hello&amp;nbsp;World&lt;/p&gt;</example>'
+    );
+    expect(
+      $$.convert(
+        { example: "&notanentity&lt;" },
+        { format: "xml", noDoubleEncoding: true }
+      )
+    ).toBe('<?xml version="1.0"?><example>&amp;notanentity&lt;</example>');
+  });
+});

--- a/test/writers/XMLWriter.test.ts
+++ b/test/writers/XMLWriter.test.ts
@@ -589,45 +589,45 @@ describe('XMLWriter', () => {
   test('No double encoding', () => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
     expect($$.create(obj).end({ noDoubleEncoding: true })).toBe(
       '<?xml version="1.0"?>' +
-      '<root att="attribute value with &num; and &#35;">' +
-      'HTML entities for umlaut are &uuml; and &#252;.' +
+      '<root att="attribute value with &amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp; and &amp;#38;.' +
       '</root>')
   })
 
   test('Double encoding', () => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
     expect($$.create(obj).end({ noDoubleEncoding: false })).toBe(
       '<?xml version="1.0"?>' +
-      '<root att="attribute value with &amp;num; and &amp;#35;">' +
-      'HTML entities for umlaut are &amp;uuml; and &amp;#252;.' +
+      '<root att="attribute value with &amp;amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp;amp; and &amp;#38;.' +
       '</root>')
   })
 
   test('Double encoding - default behavior', () => {
     const obj = {
       root: {
-        '@att': 'attribute value with &num; and &#35;',
-        '#': 'HTML entities for umlaut are &uuml; and &#252;.'
+        '@att': 'attribute value with &amp; and &#38;',
+        '#': 'XML entities for ampersand are &amp; and &#38;.'
       }
     }
 
     expect($$.create(obj).end()).toBe(
       '<?xml version="1.0"?>' +
-      '<root att="attribute value with &amp;num; and &amp;#35;">' +
-      'HTML entities for umlaut are &amp;uuml; and &amp;#252;.' +
+      '<root att="attribute value with &amp;amp; and &amp;#38;">' +
+      'XML entities for ampersand are &amp;amp; and &amp;#38;.' +
       '</root>')
   })
 


### PR DESCRIPTION
Fixes #16

The `\S+` in the regular expression has two problems:

1. It’s greedy, so it matches something like `&notanentity&lt;` and prevents the first `&` from being encoded.

2. It allows **any** entity to pass through unencoded, but XML only recognizes [a few](https://www.w3.org/TR/REC-xml/#sec-predefined-ent) entities.

The solution here to not double encode only the few entities recognized by XML. This results in things like `&nbsp;` being encoded into `&amp;nbsp;`, which [seems to be what we want](https://validator.w3.org/feed/docs/error/UndefinedNamedEntity.html).

You may want to backport this fix to xmlbuilder.