### PR TITLE
Prevent double encoding of &#xD; &#xA; &#x9; characters

### DIFF
--- a/src/builder/XMLBuilderCBImpl.ts
+++ b/src/builder/XMLBuilderCBImpl.ts
@@ -205,7 +205,7 @@ export class XMLBuilderCBImpl extends EventEmitter implements XMLBuilderCB {
 
     let markup = ""
     if (this._options.noDoubleEncoding) {
-      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
+      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot|#xD|#xA|#x9);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
     } else {
@@ -672,7 +672,7 @@ export class XMLBuilderCBImpl extends EventEmitter implements XMLBuilderCB {
     if (value === null) return ""
 
     if (this._options.noDoubleEncoding) {
-      return value.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
+      return value.replace(/(?!&(lt|gt|amp|apos|quot|#xD|#xA|#x9);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')

--- a/src/writers/BaseWriter.ts
+++ b/src/writers/BaseWriter.ts
@@ -931,7 +931,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
     let markup = ""
 
     if (noDoubleEncoding) {
-      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
+      markup = node.data.replace(/(?!&(lt|gt|amp|apos|quot|#xD|#xA|#x9);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
     } else {
@@ -1614,7 +1614,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * also replacing ">" characters.
      */
     if (noDoubleEncoding) {
-      return value.replace(/(?!&(lt|gt|amp|apos|quot);)&/g, '&amp;')
+      return value.replace(/(?!&(lt|gt|amp|apos|quot|#xD|#xA|#x9);)&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')

--- a/test/issues/issue-026.test.ts
+++ b/test/issues/issue-026.test.ts
@@ -1,0 +1,17 @@
+import $$ from "../TestHelpers";
+
+describe("Replicate issue", () => {
+  // https://github.com/oozcitak/xmlbuilder2/issues/26
+  test("#26 - double encoding of &#x9; &#xD; &#xA;", () => {
+    const root = $$.create().ele('parent', {
+      text: 'Hello&#x9;World!&#xD;&#xA;'
+    }).ele('child').txt('Line&#x9;1&#xD;&#xA;Line 2&#xD;&#xA;Line 3')
+    
+    expect(root.end({ headless: true, prettyPrint: true, noDoubleEncoding: true, newline: '\r\n' })).toBe(
+    '<parent text="Hello&#x9;World!&#xD;&#xA;">\r\n' +
+    '  <child>Line&#x9;1&#xD;&#xA;Line 2&#xD;&#xA;Line 3</child>\r\n' +
+    '</parent>'
+    )
+  })
+
+})


### PR DESCRIPTION
Fixes https://github.com/oozcitak/xmlbuilder2/issues/26

**Type of change**:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update