### PR TITLE
Allow skipWhitespaceOnlyText lexer option to be configurable

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,6 +37,12 @@ export interface XMLBuilderOptions {
    * objects to nodes
    */
   ignoreConverters: boolean
+
+  /**
+   * Whether whitespace-only text nodes are skipped or not.
+   */
+  skipWhitespaceOnlyText: boolean
+
   /** 
    * Defines string keys used while converting JS objects to nodes.
    */
@@ -116,6 +122,7 @@ export const DefaultBuilderOptions: XMLBuilderOptions = {
   keepNullNodes: false,
   keepNullAttributes: false,
   ignoreConverters: false,
+  skipWhitespaceOnlyText: true,
   convert: {
     att: "@",
     ins: "?",

--- a/src/readers/XMLReader.ts
+++ b/src/readers/XMLReader.ts
@@ -3,6 +3,7 @@ import {
   TokenType, DeclarationToken, DocTypeToken, CDATAToken, CommentToken,
   TextToken, PIToken, ElementToken
 } from "@oozcitak/dom/lib/parser/interfaces"
+import { NodeType } from "@oozcitak/dom/lib/dom/interfaces"
 import { namespace as infraNamespace } from "@oozcitak/infra"
 import { namespace_extractQName } from "@oozcitak/dom/lib/algorithm"
 import { XMLBuilder, XMLBuilderOptions } from "../interfaces"
@@ -62,6 +63,7 @@ export class XMLReader extends BaseReader<string> {
           context = this.instruction(context, this.sanitize(pi.target), this.sanitize(pi.data)) || context
           break
         case TokenType.Text:
+          if(context.node.nodeType === NodeType.Document) break
           const text = <TextToken>token
           context = this.text(context, this._decodeText(this.sanitize(text.data))) || context
           break

--- a/src/readers/XMLReader.ts
+++ b/src/readers/XMLReader.ts
@@ -20,7 +20,7 @@ export class XMLReader extends BaseReader<string> {
    * @param str - XML document string to parse
    */
   _parse(node: XMLBuilder, str: string): XMLBuilder {
-    const lexer = new XMLStringLexer(str, { skipWhitespaceOnlyText: true })
+    const lexer = new XMLStringLexer(str, { skipWhitespaceOnlyText: this._builderOptions.skipWhitespaceOnlyText })
 
     let lastChild = node
     let context = node

--- a/test/readers/XMLReader.custom.test.ts
+++ b/test/readers/XMLReader.custom.test.ts
@@ -91,4 +91,31 @@ describe('custom XMLReader', () => {
     })
   })
 
+  test("skip whitespace only text", () => {
+    const xml = $$.t`
+    <?xml version="1.0"?>
+    <root>
+      <ele>      </ele>
+    </root>`
+
+    const doc = $$.create({ skipWhitespaceOnlyText: true }, xml).doc()
+    expect(doc.end()).toBe(`<?xml version="1.0"?><root><ele/></root>`)
+  })
+
+  test("retain whitespace only text", () => {
+    const xml = $$.t`
+    <?xml version="1.0"?>
+    <root>
+      <ele>    </ele>
+    </root>`
+
+    const doc = $$.create({ skipWhitespaceOnlyText: false }, xml).doc()
+
+    expect(doc.end()).toBe(
+      $$.t`
+      <?xml version="1.0"?><root>
+        <ele>    </ele>
+      </root>
+      `)
+  })
 })


### PR DESCRIPTION
I have a use case where I need whitespace inside elements to be preserved when parsing an XML string. Currently whitespace only text nodes are skipped due to the hardcoded configuration supplied to the `XMLStringLexer`. Ideally I would like this to be configurable. This PR shows what I have in mind, but I would appreciate feedback if there's a solution that would be more appropriate.

**Example**
```javascript
create(`<Element> </Element>`)
```
Currently this results in XML equivalent  to the following with significant whitespace removed:
```xml
<Element></Element>
```
What I would like is to preserve the whitespace inside an element.
```xml
<Element> </Element>
```

I'm dealing with a rich text format where it's possible I'll encounter significant whitespace within elements and currently this is being lost.

**Example**
```xml
<Paragraph><Run format="bold">Hello</Run><Run> </Run><Run format="bold">world</Run></Paragraph>
```

**Type of change**:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
