### PR TITLE
Fix typo in `using-with-external-libraries.md`

### DIFF
--- a/docs/pages/using-with-external-libraries.md
+++ b/docs/pages/using-with-external-libraries.md
@@ -59,6 +59,6 @@ const result = xml.validate(xsd); // true
 ```
 
 {% capture ts_tip %}
-  `XMLBuilder2` uses its own TypeScript interfaces for DOM nodes; which typically will not be compatible withe the interfaces exported by other libraries. TypeScript users should cast those interfaces accordingly to prevent TS 2345 errors.
+  `XMLBuilder2` uses its own TypeScript interfaces for DOM nodes; which typically will not be compatible with the interfaces exported by other libraries. TypeScript users should cast those interfaces accordingly to prevent TS 2345 errors.
 {% endcapture %}
 {% include warning.html content=ts_tip %}


### PR DESCRIPTION
Just a small typo fix one of the doc pages. Thanks!

**Type of change**:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
