### PR TITLE
Encode all Ampersands

### DIFF
--- a/src/writers/BaseWriter.ts
+++ b/src/writers/BaseWriter.ts
@@ -928,7 +928,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * 5. Replace any occurrences of ">" in markup by "&gt;".
      * 6. Return the value of markup.
      */
-    const markup = node.data.replace(/(?!&([^&; ]*);)&/g, '&amp;')
+    const markup = node.data.replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
 

--- a/test/writers/XMLWriter.test.ts
+++ b/test/writers/XMLWriter.test.ts
@@ -389,6 +389,10 @@ describe('XMLWriter', () => {
   test('escape text data', () => {
     const ele = $$.create().ele('root').txt('&<>')
     expect(ele.toString()).toBe('<root>&amp;&lt;&gt;</root>')
+    const ele1 = $$.create().ele('root').txt('&<>;')
+    expect(ele1.toString()).toBe('<root>&amp;&lt;&gt;;</root>')
+    const ele2 = $$.create().ele('root').txt('& amp;')
+    expect(ele2.toString()).toBe('<root>&amp; amp;</root>')
   })
 
   test('escape attribute value', () => {
@@ -397,6 +401,8 @@ describe('XMLWriter', () => {
     const ele2 = $$.create().ele('root').att('att', 'val')
     Object.defineProperty((ele2.node as Element).attributes.item(0), "value", { value: null })
     expect(ele2.toString()).toBe('<root att=""/>')
+    const ele3 = $$.create().ele('root').att('att', '"&<>;')
+    expect(ele3.toString()).toBe('<root att="&quot;&amp;&lt;&gt;;"/>')
   })
 
   test('duplicate attribute name not well-formed', () => {


### PR DESCRIPTION
The current regex for replacing ampersands has a flawed check to see if the ampersand is used HTML-encoded character. The regex isn't working because it ignores whitespace between the `&` and the `;` character.  Also I don't think it's the responsibility of the writer to interpret if a value has been encoded already.

Fixes #110 and #109

**Type of change**:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
