### PR TITLE
RFC: reproducer for missing default namespace on root element

### DIFF
--- a/test/callback/namespaces.test.ts
+++ b/test/callback/namespaces.test.ts
@@ -29,6 +29,20 @@ describe('namespaces', () => {
         <bar/>
       </root>`, done)
   })
+  
+  test('do not add default namespace to later elements', (done) => {
+    const xmlStream = $$.createCB({ defaultNamespace: { ele: 'default-ns' }, namespaceAlias: {other:'other-ns'}, prettyPrint: true });
+    
+    xmlStream.ele('@other', 'o:root', {'xmlns':'default-ns'})
+        .ele('foo').up()
+        .ele('bar').up().end()
+    
+    $$.expectCBResult(xmlStream, $$.t`
+      <o:root xmlns="default-ns" xmlns:o="other-ns">
+        <foo/>
+        <bar/>
+      </root>`, done)
+  })
 
   test('XML namespace', (done) => {
     const xmlStream = $$.createCB({ prettyPrint: true })

--- a/test/callback/namespaces.test.ts
+++ b/test/callback/namespaces.test.ts
@@ -15,6 +15,20 @@ describe('namespaces', () => {
         <bar/>
       </root>`, done)
   })
+  
+  test('always add the default namespace to the root element', (done) => {
+    const xmlStream = $$.createCB({ defaultNamespace: { ele: 'default-ns' }, namespaceAlias: {other:'other-ns'}, prettyPrint: true });
+    
+    xmlStream.ele('@other', 'o:root')
+        .ele('foo').up()
+        .ele('bar').up().end()
+    
+    $$.expectCBResult(xmlStream, $$.t`
+      <o:root xmlns="default-ns" xmlns:o="other-ns">
+        <foo/>
+        <bar/>
+      </root>`, done)
+  })
 
   test('XML namespace', (done) => {
     const xmlStream = $$.createCB({ prettyPrint: true })


### PR DESCRIPTION
I started to look into how to use the library and played with the _defaultNamespace_ setting.
I expected the default namespace to be added to the root element, even in case the root element is in another namespace.
Should the test case run green, or am I missing some information?


**Type of change**:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update