### PR TITLE
ampersand encoding fixes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const nonEntityAmpersandRegex = /&(?![A-Za-z]+;|#\d+;)/g;

--- a/src/writers/BaseWriter.ts
+++ b/src/writers/BaseWriter.ts
@@ -928,7 +928,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * 5. Replace any occurrences of ">" in markup by "&gt;".
      * 6. Return the value of markup.
      */
-    const markup = node.data.replace(/(?!&([^&; ]*);)&/g, '&amp;')
+    const markup = node.data.replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
 

--- a/src/writers/BaseWriter.ts
+++ b/src/writers/BaseWriter.ts
@@ -7,6 +7,7 @@ import { LocalNameSet } from "@oozcitak/dom/lib/serializer/LocalNameSet"
 import { NamespacePrefixMap } from "@oozcitak/dom/lib/serializer/NamespacePrefixMap"
 import { namespace as infraNamespace } from "@oozcitak/infra"
 import { xml_isName, xml_isLegalChar, xml_isPubidChar } from "@oozcitak/dom/lib/algorithm"
+import { nonEntityAmpersandRegex } from "../constants"
 
 /**
  * Pre-serializes XML nodes.
@@ -928,7 +929,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * 5. Replace any occurrences of ">" in markup by "&gt;".
      * 6. Return the value of markup.
      */
-    const markup = node.data.replace(/&/g, '&amp;')
+    const markup = node.data.replace(nonEntityAmpersandRegex, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
 
@@ -1597,7 +1598,7 @@ export abstract class BaseWriter<T extends BaseWriterOptions, U extends XMLSeria
      * grammar requirement in the XML specification's AttValue production by
      * also replacing ">" characters.
      */
-    return value.replace(/(?!&([^&; ]*);)&/g, '&amp;')
+    return value.replace(nonEntityAmpersandRegex, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')

--- a/test/writers/XMLWriter.test.ts
+++ b/test/writers/XMLWriter.test.ts
@@ -389,6 +389,10 @@ describe('XMLWriter', () => {
   test('escape text data', () => {
     const ele = $$.create().ele('root').txt('&<>')
     expect(ele.toString()).toBe('<root>&amp;&lt;&gt;</root>')
+    const ele1 = $$.create().ele('root').txt('&<>;')
+    expect(ele1.toString()).toBe('<root>&amp;&lt;&gt;;</root>')
+    const ele2 = $$.create().ele('root').txt('& amp;')
+    expect(ele2.toString()).toBe('<root>&amp; amp;</root>')
   })
 
   test('escape attribute value', () => {
@@ -397,6 +401,8 @@ describe('XMLWriter', () => {
     const ele2 = $$.create().ele('root').att('att', 'val')
     Object.defineProperty((ele2.node as Element).attributes.item(0), "value", { value: null })
     expect(ele2.toString()).toBe('<root att=""/>')
+    const ele3 = $$.create().ele('root').att('att', '"&<>;')
+    expect(ele3.toString()).toBe('<root att="&quot;&amp;&lt;&gt;;"/>')
   })
 
   test('duplicate attribute name not well-formed', () => {


### PR DESCRIPTION

**Type of change**:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Fix for #109 & #110
Builds on the work started in #124. Notably, my changes cause @coffeemakr's added tests to pass. 
I noticed this regex pattern was repeated multiple times, so I chose to define it once for import. Not married to this approach. Open to your thoughts.