### PR TITLE
fix(security): Bump js-yaml package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6655,9 +6655,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -8273,7 +8273,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "ssri": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@oozcitak/infra": "1.0.8",
     "@oozcitak/util": "8.3.8",
     "@types/node": "*",
-    "js-yaml": "3.14.0"
+    "js-yaml": "3.14.1"
   },
   "devDependencies": {
     "@babel/preset-env": "*",


### PR DESCRIPTION
js-yaml version 3.14.0 has a [security vulnerability](https://github.com/nodeca/js-yaml/blob/9586ebe23298427d26b3479979bd6499bf3a14c2/CHANGELOG.md#3141---2020-12-07) fixed in version 3.14.1

Reference: 

**Type of change**:

- [x] Bug fix (non-breaking change which fixes an issue)

