### PR TITLE
fix(ns): imported node namespace is not overidden when specified

### DIFF
--- a/src/builder/XMLBuilderImpl.ts
+++ b/src/builder/XMLBuilderImpl.ts
@@ -377,6 +377,17 @@ export class XMLBuilderImpl implements XMLBuilder {
 
     const importedNode = node.node
 
+    const updateImportedNodeNs = (clone: Element) => {
+      // update namespace of imported node only when not specified
+      if (!clone._namespace) {
+        const [prefix] = namespace_extractQName(
+          clone.prefix ? clone.prefix + ':' + clone.localName : clone.localName
+        );
+        const namespace = hostNode.lookupNamespaceURI(prefix)
+        new XMLBuilderImpl(clone)._updateNamespace(namespace)
+      }
+    };
+
     if (Guard.isDocumentNode(importedNode)) {
       // import document node
       const elementNode = importedNode.documentElement
@@ -385,18 +396,14 @@ export class XMLBuilderImpl implements XMLBuilder {
       }
       const clone = hostDoc.importNode(elementNode, true) as Element
       hostNode.appendChild(clone)
-      const [prefix] = namespace_extractQName(clone.prefix ? clone.prefix + ':' + clone.localName : clone.localName)
-      const namespace = hostNode.lookupNamespaceURI(prefix)
-      new XMLBuilderImpl(clone)._updateNamespace(namespace)
+      updateImportedNodeNs(clone)
     } else if (Guard.isDocumentFragmentNode(importedNode)) {
       // import child nodes
       for (const childNode of importedNode.childNodes) {
         const clone = hostDoc.importNode(childNode, true)
         hostNode.appendChild(clone)
         if (Guard.isElementNode(clone)) {
-          const [prefix] = namespace_extractQName(clone.prefix ? clone.prefix + ':' + clone.localName : clone.localName)
-          const namespace = hostNode.lookupNamespaceURI(prefix)
-          new XMLBuilderImpl(clone)._updateNamespace(namespace)
+          updateImportedNodeNs(clone)
         }
       }
     } else {
@@ -404,9 +411,7 @@ export class XMLBuilderImpl implements XMLBuilder {
       const clone = hostDoc.importNode(importedNode, true)
       hostNode.appendChild(clone)
       if (Guard.isElementNode(clone)) {
-        const [prefix] = namespace_extractQName(clone.prefix ? clone.prefix + ':' + clone.localName : clone.localName)
-        const namespace = hostNode.lookupNamespaceURI(prefix)
-        new XMLBuilderImpl(clone)._updateNamespace(namespace)
+        updateImportedNodeNs(clone)
       }
     }
 


### PR DESCRIPTION
Fixes [#178](https://github.com/oozcitak/xmlbuilder2/issues/178)

**Type of change**:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

![Screenshot 2024-04-22 at 11 02 14](https://github.com/oozcitak/xmlbuilder2/assets/761766/28364c37-f236-4460-b0cb-07065f166637)

