### PR TITLE
fix(94): fix formatting to be compliant with XMLBuilder

### DIFF
--- a/src/writers/BaseCBWriter.ts
+++ b/src/writers/BaseCBWriter.ts
@@ -103,6 +103,7 @@ export abstract class BaseCBWriter<T extends BaseCBWriterOptions> {
    * 
    * @param name - node name
    */
+  abstract closeTag(name: string, hasTextPayload?: boolean): string
   abstract closeTag(name: string): string
 
   /**

--- a/src/writers/XMLCBWriter.ts
+++ b/src/writers/XMLCBWriter.ts
@@ -55,7 +55,7 @@ export class XMLCBWriter extends BaseCBWriter<XMLCBWriterOptions> {
   }
   /** @inheritdoc */
   text(data: string): string {
-    return this._beginLine() + data
+    return data
   }
   /** @inheritdoc */
   instruction(target: string, data: string): string {
@@ -91,8 +91,9 @@ export class XMLCBWriter extends BaseCBWriter<XMLCBWriterOptions> {
     }
   }
   /** @inheritdoc */
-  closeTag(name: string): string {
-    return this._beginLine() + "</" + name + ">"
+  closeTag(name: string, hasTextPayload?: boolean): string {
+    const ending = hasTextPayload ? '' : this._beginLine();
+    return ending + "</" + name + ">";
   }
   /** @inheritdoc */
   attribute(name: string, value: string): string {

--- a/test/callback/object.test.ts
+++ b/test/callback/object.test.ts
@@ -35,40 +35,24 @@ describe('object', () => {
 
     $$.expectCBResult(xmlStream, $$.t`
     <root>
-      <ele>
-        simple element
-      </ele>
+      <ele>simple element</ele>
       <person age="35">
-        <name>
-          John
-        </name>
+        <name>John</name>
         <?pi val?>
         <?pi?>
         <!--Good guy-->
         <![CDATA[well formed!]]>
         <address>
           <?pi?>
-          <city>
-            Istanbul
-          </city>
-          <street>
-            End of long and winding road
-          </street>
+          <city>Istanbul</city>
+          <street>End of long and winding road</street>
         </address>
         <contact>
-          <phone>
-            555-1234
-          </phone>
-          <phone>
-            555-1235
-          </phone>
+          <phone>555-1234</phone>
+          <phone>555-1235</phone>
         </contact>
-        <id>
-          42
-        </id>
-        <details>
-          classified
-        </details>
+        <id>42</id>
+        <details>classified</details>
       </person>
     </root>
     `, done)    

--- a/test/callback/parse.test.ts
+++ b/test/callback/parse.test.ts
@@ -10,9 +10,7 @@ describe('parse()', () => {
     xmlStream.ele(str).end()
 
     $$.expectCBResult(xmlStream, $$.t`
-    <root att="val">
-      text
-    </root>
+    <root att="val">text</root>
     `, done)
   })
 

--- a/test/issues/issue-002.test.ts
+++ b/test/issues/issue-002.test.ts
@@ -24,20 +24,12 @@ describe("Replicate issue", () => {
     <?xml version="1.0"?>
     <rss>
       <item>
-        <sku>
-          001
-        </sku>
-        <name>
-          Product name 1
-        </name>
+        <sku>001</sku>
+        <name>Product name 1</name>
       </item>
       <item>
-        <sku>
-          002
-        </sku>
-        <name>
-          Product name 2
-        </name>
+        <sku>002</sku>
+        <name>Product name 2</name>
       </item>
     </rss>
     `, done)

--- a/test/issues/issue-078.test.ts
+++ b/test/issues/issue-078.test.ts
@@ -28,9 +28,7 @@ describe("Replicate issue", () => {
     $$.expectCBResult(xmlStream, $$.t`
     <root>
       <title/>
-      <description>
-        Test description
-      </description>
+      <description>Test description</description>
     </root>
     `, done)
   })


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Fixes # (issue number)

**Type of change**:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

This PR should fix previously reported issue https://github.com/oozcitak/xmlbuilder2/issues/94 that i also encountered. current pretty print in XMLBuilderCB prints values on separate lines like:

```xml
<Root>
   <Test>
   value
   </Test>
</Root>
```

but it should be

```xml
<Root>
   <Test>value</Test>
</Root>
```

the main problem is that pretty printed xml in that way may not pass xsd validation, because printer adds spaces and '\n's.

This might be a naive approach, so i would appreciate review from codeowner
