### PR TITLE
Remove browser attribute from package.json, as webpack seems to be disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "http://github.com/oozcitak/xmlbuilder2/issues"
   },
   "main": "./lib/index",
-  "type": "module",
+  "type": "commonjs",
   "engines": {
     "node": ">=20.0"
   },


### PR DESCRIPTION
Fixes #207

Notably:

* This removes the `browser` attribute from `package.json`
* It adds a property saying the module is `commonjs` to prevent tools such as `vite` from assuming ESM
* I believe that script would have been built by webpack, but as of a month ago (in [this commit](https://github.com/oozcitak/xmlbuilder2/commit/8d26d39ac7f6a4a6f5dc469e5b6e78ae49099af3)), webpack appears to have been removed.
* I also tried re-enabling webpack, but was unable to get it to build. I'm not super familiar with webpack, so was unable to resolve this. As such, v4 still cannot be used in browsers.

For the time being, removing `browser` should allow it to be used in tools like `vite`, at least in back-end components.

In future, adding `publint` to CI would be very helpful for preventing these regressions.